### PR TITLE
remove unnecessary single quote from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and looks like this:
 
 `:destination` specifies where to copy the jars. You can then specify the jars you want to copy in this fashion:
 
-    :jar-copier {:jars        '[[org.clojure/clojure "1.7.0"]]
+    :jar-copier {:jars        [[org.clojure/clojure "1.7.0"]]
                  :destination "resources/jars"}
 
 or, if you have `:java-agents` in your project, there's a shortcut to just copy them:


### PR DESCRIPTION
The quote causes a `java.lang.IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Symbol`